### PR TITLE
convert_files outpath fix and README example fixes

### DIFF
--- a/R/convert_files.R
+++ b/R/convert_files.R
@@ -28,7 +28,7 @@ convert_files <-
     if (is.null(outpath)) {
       mount_out <- mount_point
     } else{
-      mount_out <- outpath
+      mount_out <- normalizePath(outpath)
     }
 
 

--- a/R/convert_files.R
+++ b/R/convert_files.R
@@ -43,10 +43,14 @@ convert_files <-
         'chambm/pwiz-skyline-i-agree-to-the-vendor-licenses wine msconvert '
       )
 
-    command_args <- list()
-    for (i in seq_along(args)) {
-      command_args[[i]] <- paste0('--filter ', '"', args[i], '"')
+    if (nchar(args) > 0){
+      command_args <- lapply(args,function(x){
+        paste0('--filter ', '"', x, '"')
+      })
+    } else {
+      command_args <- list()
     }
+
 
     command_args <-
       paste0(' --mzML ', do.call('paste', command_args))

--- a/R/get_pwiz_container.R
+++ b/R/get_pwiz_container.R
@@ -13,10 +13,10 @@ get_pwiz_container <- function()
 
 
   if (TRUE %in%
-      stringr::str_detect(
-        image_list$repo_tags,
-        'chambm/pwiz-skyline-i-agree-to-the-vendor-licenses:latest'
-      )) {
+      unlist(
+        lapply(
+          image_list$repo_tags,stringr::str_detect,
+          string = 'chambm/pwiz-skyline-i-agree-to-the-vendor-licenses:latest'))) {
     message(crayon::green(clisymbols::symbol$tick, 'pwiz container avaialble'))
   } else{
     message(crayon::red(clisymbols::symbol$cross, 'pwiz container not available'))

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All file conversions are performed by the `convert_files` function. Conversion p
 ```
 > rawfile <- system.file('QC01.raw',package = 'msconverteR')
 
-> convert_files(rawfiles, outpath =  NULL, args = 'peakPicking true 1-')
+> convert_files(rawfile, outpath =  NULL, args = 'peakPicking true 1-')
 
 format: mzML 
     m/z: Compression-None, 64-bit

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ get_pwiz_container()
 All file conversions are performed by the `convert_files` function. Conversion parameters are passed to the the `args` parameter in the same way as they would be for `msconvert` except that the `--filter` prefix is omitted. 
 
 ```
-> rawfile <- 'inst/QC01.raw'
+> rawfile <- system.file('QC01.raw',package = 'msconverteR')
 
 > convert_files(rawfiles, outpath =  NULL, args = 'peakPicking true 1-')
 


### PR DESCRIPTION
`outpath` argument for`convert_files()` now normalised to full system path to enable converted file output to the current working directory via `"."`. Fixed the README example code to enable it to run out of the box.