### PR TITLE
Argument added to msconverteR::convert_files() to allow arguments to be passed to docker run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     clisymbols
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests: 
     testthat

--- a/man/convert_files.Rd
+++ b/man/convert_files.Rd
@@ -7,7 +7,8 @@
 convert_files(
   files,
   outpath = NULL,
-  args = c("peakPicking true1-", "polarity positive")
+  msconvert_args = c("peakPicking true1-", "polarity positive"),
+  docker_args = c()
 )
 }
 \arguments{
@@ -15,7 +16,9 @@ convert_files(
 
 \item{outpath}{an optional filepath where \code{.mzML} files will be saved to. If \code{NULL} then \code{.mzML} files are saved to the same location as input files.}
 
-\item{args}{a character vector of \code{msconvert} arguments.}
+\item{msconvert_args}{a character vector of arguments to pass to \code{msconvert}.}
+
+\item{docker_args}{additional arguments to pass to \verb{docker run}}
 }
 \description{
 Convert vendor specific mass spectrometry files to the open \code{.mzML} format. This functions makes a \code{system} call to \code{docker} in order to convert files.


### PR DESCRIPTION

* Docker mount point path now normalised to ensure it is passed safely to docker.

* `msconverteR::convert_files()` argument `args` changed to `msconvert_args`.

* `docker_args` argument added to `msconverteR::convert_files()` to enable arguments to be passed to `docker run`.